### PR TITLE
timeout added to http requests

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -267,13 +267,14 @@ class CB(object):
 
 class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
     def __init__(self, host='127.0.0.1', port=8500, scheme='http',
-                 verify=True, cert=None):
+                 verify=True, cert=None, timeout=None):
         self.host = host
         self.port = port
         self.scheme = scheme
         self.verify = verify
         self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
         self.cert = cert
+        self.timeout = timeout
 
     def uri(self, path, params=None):
         uri = self.base_uri + urllib.parse.quote(path, safe='/:')

--- a/consul/std.py
+++ b/consul/std.py
@@ -22,28 +22,28 @@ class HTTPClient(base.HTTPClient):
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.get(uri, verify=self.verify, cert=self.cert)))
+            self.session.get(uri, verify=self.verify, cert=self.cert, timeout=self.timeout)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
             self.session.put(uri, data=data, verify=self.verify,
-                             cert=self.cert)))
+                             cert=self.cert, timeout=self.timeout)))
 
     def delete(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
             self.session.delete(uri, data=data, verify=self.verify,
-                                cert=self.cert)))
+                                cert=self.cert, timeout=self.timeout)))
 
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
             self.session.post(uri, data=data, verify=self.verify,
-                              cert=self.cert)))
+                              cert=self.cert, timeout=self.timeout)))
 
 
 class Consul(base.Consul):
     @staticmethod
-    def http_connect(host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify, cert)
+    def http_connect(host, port, scheme, verify=True, cert=None, timeout=None):
+        return HTTPClient(host, port, scheme, verify, cert, timeout)

--- a/consul/std.py
+++ b/consul/std.py
@@ -22,7 +22,8 @@ class HTTPClient(base.HTTPClient):
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.get(uri, verify=self.verify, cert=self.cert, timeout=self.timeout)))
+            self.session.get(uri, verify=self.verify, cert=self.cert,
+                             timeout=self.timeout)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -16,7 +16,7 @@ Request = collections.namedtuple(
 
 class HTTPClient(object):
     def __init__(self, host=None, port=None, scheme=None,
-                 verify=True, cert=None):
+                 verify=True, cert=None, timeout=None):
         pass
 
     def get(self, callback, path, params=None):
@@ -30,8 +30,8 @@ class HTTPClient(object):
 
 
 class Consul(consul.base.Consul):
-    def http_connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify=verify, cert=None)
+    def http_connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
+        return HTTPClient(host, port, scheme, verify=verify, cert=None, timeout=None)
 
 
 def _should_support(c):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -30,8 +30,10 @@ class HTTPClient(object):
 
 
 class Consul(consul.base.Consul):
-    def http_connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
-        return HTTPClient(host, port, scheme, verify=verify, cert=None, timeout=None)
+    def http_connect(self, host, port, scheme, verify=True, cert=None,
+                     timeout=None):
+        return HTTPClient(host, port, scheme, verify=verify, cert=None,
+                          timeout=None)
 
 
 def _should_support(c):


### PR DESCRIPTION
In our environment, http requests to consul get sometimes stuck because of missing timeout. I duplicated original pull request by @Chimney42 to @cablehead python-consul repo.