### PR TITLE
Fix Policy update and create bug when description is None.

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -923,9 +923,9 @@ class Consul(object):
                 payload = {"Name": name}
                 if description:
                     payload['Description'] = description
-                if description:
+                if rules:
                     payload['Rules'] = rules
-                if description:
+                if datacenters:
                     payload['Datacenters'] = datacenters
 
                 headers = {}
@@ -954,9 +954,9 @@ class Consul(object):
                 payload = {"Name": name}
                 if description:
                     payload['Description'] = description
-                if description:
+                if rules:
                     payload['Rules'] = rules
-                if description:
+                if datacenters:
                     payload['Datacenters'] = datacenters
 
                 path = '/v1/acl/policy/%s' % policy_id


### PR DESCRIPTION
Policy create and update routines contain a code block which tests for the
presence of function parameters to determine json payload. As currently
implemented both the "rules" and "datacenters" fields are determined by
whether the "description" parameter is defined.