### PR TITLE
Support skipnodeupdate parameter

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.1.2
+current_version = 0.1.3-dev
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,3 +57,10 @@ Features
 Features
 ~~~~~~~~
 * `long_description` has syntax errors in markup and would not be rendered on PyPI.
+
+0.1.3
+-----
+
+Features
+~~~~~~~~
+* Support `SkipNodeUpdate` parameter

--- a/consul/__init__.py
+++ b/consul/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.2'
+__version__ = '0.1.3-dev'
 
 from consul.base import ACLDisabled  # noqa
 from consul.base import ACLPermissionDenied  # noqa

--- a/consul/base.py
+++ b/consul/base.py
@@ -1676,6 +1676,7 @@ class Consul(object):
                      node,
                      address,
                      service=None,
+                     skipnodeupdate=False,
                      check=None,
                      dc=None,
                      token=None,
@@ -1712,6 +1713,11 @@ class Consul(object):
 
                 *Tags* and *Port* are optional.
 
+            *skipnodeupdate* is an optional boolean which, when set to True,
+            skips updating the node's information during registration. By
+            default, it is set to False. For information on this parameter, see
+            `here <https://www.consul.io/api-docs/catalog#skipnodeupdate`_.
+
             *check* is an optional check to register. if supplied this is a
             dict::
 
@@ -1746,6 +1752,8 @@ class Consul(object):
                 data['datacenter'] = dc
             if service:
                 data['service'] = service
+            if skipnodeupdate:
+                data['skipnodeupdate'] = True
             if check:
                 data['check'] = check
             token = token or self.agent.token

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Required metadata
 sonar.projectKey=com.github:poppyred:python-consul2
 sonar.projectName=Python Consul2
-sonar.projectVersion=0.1.2
+sonar.projectVersion=0.1.3-dev
 
 # Comma-separated paths to directories with sources (required)
 sonar.sources=consul


### PR DESCRIPTION
Add support for the [`SkipNodeUpdate`](https://www.consul.io/api-docs/catalog#skipnodeupdate) entity registration parameter