### PR TITLE
Fix AIOHTTP crashing on startup.

### DIFF
--- a/consul/aio.py
+++ b/consul/aio.py
@@ -17,6 +17,7 @@ class HTTPClient(base.HTTPClient):
 
     def __init__(self, *args, loop=None, **kwargs):
         super(HTTPClient, self).__init__(*args, **kwargs)
+        self._session = None
         self._loop = loop or asyncio.get_event_loop()
 
     async def _request(self, callback, method, uri, data=None, headers=None):
@@ -41,7 +42,7 @@ class HTTPClient(base.HTTPClient):
         def __del__(self):
             warnings.warn("Unclosed connector in aio.Consul.HTTPClient",
                           ResourceWarning)
-            if not self._session.closed:
+            if self._session and not self._session.closed:
                 warnings.warn("Unclosed connector in aio.Consul.HTTPClient",
                               ResourceWarning)
                 asyncio.ensure_future(self.close())


### PR DESCRIPTION
If you do not call any HTTP request method using a session then the session won't exists and calling "close" on a Consul class results in an exception. This prevents the library from crashing.

Example:
```
Exception ignored in: <function HTTPClient.__del__ at >
Traceback (most recent call last):
  File "/home/dev/.local/lib/python3.8/site-packages/consul/aio.py", line 44, in __del__
    if not self._session.closed:
AttributeError: 'HTTPClient' object has no attribute '_session'
```