### PR TITLE
Run tests on Python 3.9

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        name: 
+        name:
           - "py27"
           - "py35"
           - "py36"
@@ -56,6 +56,13 @@ jobs:
             python: "3.8"
             os: ubuntu-latest
             tox_env: "py38"
+            use_coverage: false
+            consul_version: "1.6.1"
+
+          - name: "py39"
+            python: "3.9"
+            os: ubuntu-latest
+            tox_env: "py39"
             use_coverage: false
             consul_version: "1.6.1"
 
@@ -178,5 +185,3 @@ jobs:
           env_vars: OS,PYTHON
           name: codecov-umbrella
           fail_ci_if_error: true
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, pypy2, pypy3
+envlist = py27, py35, py36, py37, py38, py39, pypy2, pypy3
 
 
 [testenv]
@@ -123,6 +123,24 @@ commands =
 
 
 [testenv:py38]
+
+deps =
+    pytest
+    pytest-rerunfailures
+    pytest-twisted
+    twisted
+    treq
+    pytest_httpserver
+    pyOpenSSL
+    tornado
+    aiohttp
+    flake8
+commands =
+    py.test --reruns=3 {posargs:consul tests}
+    flake8 --exclude=".tox/*,xx/*,__*,docs/*,venv/*"
+
+
+[testenv:py39]
 
 deps =
     pytest


### PR DESCRIPTION
We need to ensure this library runs on 3.9 for Celery's Consul result backend.