### PR TITLE
Enable retries in the std.py backend.

### DIFF
--- a/consul/std.py
+++ b/consul/std.py
@@ -71,5 +71,6 @@ class HTTPClient(base.HTTPClient):
 
 class Consul(base.Consul):
     @staticmethod
-    def http_connect(host, port, scheme, verify=True, cert=None, timeout=None, **kwargs):
+    def http_connect(host, port, scheme, verify=True, cert=None, timeout=None,
+                     **kwargs):
         return HTTPClient(host, port, scheme, verify, cert, timeout, **kwargs)


### PR DESCRIPTION
 Resolves #30. This PR also:

- Replaces the deprecated call to requests.session() with its
  current counterpart, requests.Session().
- Allows arbitrary connection kwargs to be passed down, not least
  to allow the new retry behaviour to be overridden.